### PR TITLE
add support for AWS Lambda options (to add credentials)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This module is used to standardize the http to lambda mapping and function invoc
 ## Usage
 ```
 var lambda_http_proxy = require('lambda_http_proxy');
-app.all('/api', lambda_http_proxy.invoke);
+app.all('/api', lambda_http_proxy.invoke());
 ```
 
 The following headers are supported/required:

--- a/index.js
+++ b/index.js
@@ -91,17 +91,21 @@ functions.map_response = function(err, data, res) {
  * @param res
  * @param callback
  */
-functions.invoke = function (req, res, next) {
+functions.invoke = function(options) {
+  options = options || {};
+
+  return function invoke(req, res, next) {
     if (_.isNil(req.header('x-FunctionName'))) {
         res.status(400).send("Please provide an AWS Lambda function name in the form of a 'x-FunctionName' header.");
         return next();
     }
-    var region = !_.isNil(req.header('x-Region')) ? req.header('x-Region') : 'us-east-1';
-    var lambda = new AWS.Lambda({region:region});
+    options.region = !_.isNil(req.header('x-Region')) ? req.header('x-Region') : 'us-east-1';
+    var lambda = new AWS.Lambda(options);
     lambda.invoke(functions.map_request(req), function (err, data) {
         functions.map_response(err, data, res);
         return next();
     });
+  }
 };
 
 module.exports = functions;

--- a/test/app.js
+++ b/test/app.js
@@ -8,7 +8,7 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 
-app.all('/api', lambda_http_proxy.invoke);
+app.all('/api', lambda_http_proxy.invoke());
 app.all('/map-request', function(req, res, next) {
     res.status(200);
     res.json(lambda_http_proxy.map_request(req));


### PR DESCRIPTION
Change the invoke property from direct middleware to a function that accepts an options object and returns a middleware function.

This options object should be the same as used on the AWS.Lambda constructor
http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Lambda.html#constructor-property