### PR TITLE
Ability to change response format by setting a HTTP Header.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ jspm_packages
 .node_repl_history
 
 .idea
+.nyc_output
+coverage

--- a/README.md
+++ b/README.md
@@ -11,16 +11,27 @@ The following headers are supported/required:
 * x-FunctionName, Required, Lambda function name.
 * x-LogType, Optional, None or Tail.
 * x-Qualifier, Optional
+* x-ViewType, Optional, simple or standard; defaults to standard.
+
+The following headers are supported/optional:
+* x-ViewType
 
 See the Lambda function params here for more information:  http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Lambda.html#invoke-property
 
-The response structure looks like:
+The standard response structure looks like:
 ```
 {
     StatusCode: data.StatusCode,
     FunctionError: data.FunctionError,
     LogResult: data.LogResult,
     Payload: !_.isNil(data.Payload) ? JSON.parse(data.Payload) : null
+}
+```
+
+The simple response structure looks like:
+```
+{
+    <contents of Payload.body>
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "lambda-http-proxy",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Proxy http requests to lambda functions",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "nyc --reporter=text --reporter=html mocha"
   },
   "repository": {
     "type": "git",
@@ -34,6 +34,7 @@
     "cookie-parser": "^1.4.3",
     "express": "^4.14.0",
     "mocha": "^3.1.2",
+    "nyc": "^13.1.0",
     "should": "^11.1.1",
     "supertest": "^2.0.1"
   }

--- a/test/app.js
+++ b/test/app.js
@@ -13,8 +13,11 @@ app.all('/map-request', function(req, res, next) {
     res.status(200);
     res.json(lambda_http_proxy.map_request(req));
 });
-app.all('/map-response', function(req, res, next) {
-    lambda_http_proxy.map_response(req.body.err, req.body.data, res);
+app.all('/map-response-standard', function(req, res, next) {
+    lambda_http_proxy.map_response_standard(req.body.err, req.body.data, res);
+});
+app.all('/map-response-simple', function(req, res, next) {
+    lambda_http_proxy.map_response_simple(req.body.err, req.body.data, res);
 });
 
 app.set('port', 3000);

--- a/test/test.js
+++ b/test/test.js
@@ -26,6 +26,22 @@ describe('Test', function(){
             .set('x-FunctionName', 'not-found')
             .expect(500, done);
     });
+    it('invalid function name standard ViewType', function(done){
+        request(app)
+            .get('/api')
+            .set('Accept', 'application/json')
+            .set('x-FunctionName', 'not-found')
+            .set('x-ViewType', 'standard')
+            .expect(500, done);
+    });
+    it('invalid function name simple ViewType', function(done){
+        request(app)
+            .get('/api')
+            .set('Accept', 'application/json')
+            .set('x-FunctionName', 'not-found')
+            .set('x-ViewType', 'simple')
+            .expect(500, done);
+    });
     it('Test request mapping', function(done){
         request(app)
             .post('/map-request?param1=yes&param2=no')
@@ -52,9 +68,9 @@ describe('Test', function(){
             })
             .end(done);
     });
-    it('Test response mapping', function(done){
+    it('Test standard response mapping', function(done){
         request(app)
-            .post('/map-response')
+            .post('/map-response-standard')
             .set('Accept', 'application/json')
             .send({
                 data: {
@@ -76,9 +92,9 @@ describe('Test', function(){
             })
             .end(done);
     });
-    it('Test response mapping - 500', function(done){
+    it('Test standard response mapping - 500', function(done){
         request(app)
-            .post('/map-response')
+            .post('/map-response-standard')
             .set('Accept', 'application/json')
             .send({
                 data: {
@@ -101,9 +117,9 @@ describe('Test', function(){
             })
             .end(done);
     });
-    it('Test response mapping - 400', function(done){
+    it('Test standard response mapping - 400', function(done){
         request(app)
-            .post('/map-response')
+            .post('/map-response-standard')
             .set('Accept', 'application/json')
             .send({
                 data: {
@@ -122,9 +138,9 @@ describe('Test', function(){
             })
             .end(done);
     });
-    it('Test response mapping - headers, cookies', function(done){
+    it('Test standard response mapping - headers, cookies', function(done){
         request(app)
-            .post('/map-response')
+            .post('/map-response-standard')
             .set('Accept', 'application/json')
             .send({
                 data: {
@@ -153,6 +169,110 @@ describe('Test', function(){
                 assert.equal(res.status, 200, 'statusCode should be 200, was:'+res.statusCode);
                 assert.equal(res.body.StatusCode, 200);
                 assert.equal(res.body.Payload.foo, 'bar');
+                assert.equal(res.get('header1'), 'value1');
+            })
+            .end(done);
+    });
+    it('Test simple response mapping', function(done){
+        request(app)
+            .post('/map-response-simple')
+            .set('Accept', 'application/json')
+            .send({
+                data: {
+                    StatusCode: 200,
+                    LogResult: 'logresult',
+                    Payload: JSON.stringify({
+                        statusCode: 200,
+                        body: {
+                            foo: 'bar'
+                        }
+                    })
+                }
+            })
+            .expect(function (res) {
+                winston.info(JSON.stringify(res.body, null, 3));
+                assert.equal(res.statusCode, 200, 'statusCode should be 200, was:'+res.statusCode);
+                assert.equal(res.body.foo, 'bar');
+            })
+            .end(done);
+    });
+    it('Test simple response mapping - 500', function(done){
+        request(app)
+            .post('/map-response-simple')
+            .set('Accept', 'application/json')
+            .send({
+                data: {
+                    StatusCode: 500,
+                    FunctionError: 'error',
+                    Payload: JSON.stringify({
+                        statusCode: 200,
+                        body: {
+                            foo: 'bar'
+                        }
+                    })
+                }
+            })
+            .expect(function (res) {
+                winston.info(JSON.stringify(res.body, null, 3));
+                assert.equal(res.statusCode, 500, 'statusCode should be 500, was:'+res.statusCode);
+                assert.equal(res.body.StatusCode, null);
+                assert.equal(res.body.FunctionError, null);
+                assert.equal(res.body.foo, 'bar');
+            })
+            .end(done);
+    });
+    it('Test simple response mapping - 400', function(done){
+        request(app)
+            .post('/map-response-standard')
+            .set('Accept', 'application/json')
+            .send({
+                data: {
+                    StatusCode: 200,
+                    Payload: JSON.stringify({
+                        statusCode: 400,
+                        body: {
+                            foo: 'bar'
+                        }
+                    })
+                }
+            })
+            .expect(function (res) {
+                winston.info(JSON.stringify(res, null, 3));
+                assert.equal(res.status, 400, 'statusCode should be 400, was:'+res.status);
+            })
+            .end(done);
+    });
+    it('Test simple response mapping - headers, cookies', function(done){
+        request(app)
+            .post('/map-response-simple')
+            .set('Accept', 'application/json')
+            .send({
+                data: {
+                    StatusCode: 200,
+                    LogResult: 'logresult',
+                    Payload: JSON.stringify({
+                        statusCode: 200,
+                        body: {
+                            foo: 'bar'
+                        },
+                        headers: {
+                            'header1': 'value1'
+                        },
+                        cookies: [
+                            {
+                                name: 'cookie1',
+                                value: 'value1',
+                                options: { maxAge: 900000, httpOnly: true }
+                            }
+                        ]
+                    })
+                }
+            })
+            .expect(function (res) {
+                winston.info(JSON.stringify(res.body, null, 3));
+                assert.equal(res.status, 200, 'statusCode should be 200, was:'+res.statusCode);
+                assert.equal(res.body.StatusCode, null);
+                assert.equal(res.body.foo, 'bar');
                 assert.equal(res.get('header1'), 'value1');
             })
             .end(done);


### PR DESCRIPTION
### What's changed?
Added a new response format that returns just Payload.body in the response body instead of JSON of the format below.
```
{
  "StatusCode":"200",
  "FunctionError":"blahblah",
  "LogResult":"blahblah",
  "Payload":"blahblah"
}
```
Requests that include a X-ViewType header with value of 'simple' will trigger the use of the new response view.  The absence of X-ViewType header or a value of 'standard' will use the current response view.

Pub Stack Team needs this functionality in Trident for REST APIs we are building in Lambda.

### How was it tested?
Unit tests and manually in Trident.