### PR TITLE
Ability to change response format by setting a HTTP Header.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ jspm_packages
 .node_repl_history
 
 .idea
+.nyc_output
+coverage

--- a/README.md
+++ b/README.md
@@ -11,16 +11,24 @@ The following headers are supported/required:
 * x-FunctionName, Required, Lambda function name.
 * x-LogType, Optional, None or Tail.
 * x-Qualifier, Optional
+* x-ViewType, Optional, default or simple; defaults to default.
 
 See the Lambda function params here for more information:  http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Lambda.html#invoke-property
 
-The response structure looks like:
+The default response structure looks like:
 ```
 {
     StatusCode: data.StatusCode,
     FunctionError: data.FunctionError,
     LogResult: data.LogResult,
     Payload: !_.isNil(data.Payload) ? JSON.parse(data.Payload) : null
+}
+```
+
+The simple response structure looks like:
+```
+{
+    <contents of Payload.body>
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -17,71 +17,106 @@ var functions = {};
  * @returns {{FunctionName, Payload}}
  */
 functions.map_request = function(req) {
-    var log_type = !_.isNil(req.header('x-LogType')) ? req.header('x-LogType') : 'None';
-    return {
-        FunctionName: req.header('x-FunctionName'),
-        InvocationType: 'RequestResponse',
-        LogType: log_type,
-        Payload: JSON.stringify({
-            method: req.method,
-            headers: req.headers,
-            body : req.body,
-            cookies : req.cookies,
-            url : req.originalUrl,
-            path : '/'+_.trim(req.path, '/'),
-            protocol : req.protocol,
-            query : req.query
-        }),
-        Qualifier: req.header('x-Qualifier')
-    };
+  var log_type = !_.isNil(req.header('x-LogType')) ? req.header('x-LogType') : 'None';
+  return {
+    FunctionName: req.header('x-FunctionName'),
+    InvocationType: 'RequestResponse',
+    LogType: log_type,
+    Payload: JSON.stringify({
+      method: req.method,
+      headers: req.headers,
+      body : req.body,
+      cookies : req.cookies,
+      url : req.originalUrl,
+      path : '/'+_.trim(req.path, '/'),
+      protocol : req.protocol,
+      query : req.query
+    }),
+    Qualifier: req.header('x-Qualifier')
+  };
 };
 
-functions.map_response = function(err, data, res) {
-    if (err) {
-        winston.error(err);
-        res.status(500).send(err);
-    } else {
-        var payload = !_.isNil(data.Payload) ? JSON.parse(data.Payload) : null;
-        var statusCode = _.isEqual(data.StatusCode, 200) && !_.isNull(payload) && !_.isNull(payload.statusCode) ? payload.statusCode : data.StatusCode;
-        if (!_.isNil(data.FunctionError)) {
-            statusCode = 500;
-        }
-        res.status(statusCode);
-        if (!_.isNil(payload) && !_.isNil(payload.headers) && !_.isEmpty(payload.headers)) {
-            res.set(payload.headers);
-        }
-        if (!_.isNil(payload) && !_.isNil(payload.cookies) && !_.isEmpty(payload.cookies)) {
-            _.forEach(payload.cookies, function(cookie) {
-               res.cookie(cookie.name, cookie.value, cookie.options);
-            });
-        }
-        if (!_.isNil(payload) && !_.isNil(payload.redirect)) {
-            res.redirect(statusCode, payload.redirect);
-        } else {
-            if (!_.isNil(payload) && !_.isNil(payload.body)) {
-                var payload_out = payload.body;
-            } else if (!_.isNil(payload)) {
-                var payload_out = payload;
-            } else {
-                var payload_out = null;
-            }
-            var log_result = data.LogResult;
-            if (!_.isNil(log_result)) {
-                try {
-                    var b = new Buffer(log_result, 'base64')
-                    log_result = b.toString();
-                } catch (err) {
-                    winston.error(err);
-                }
-            }
-            res.json({
-                StatusCode: statusCode,
-                FunctionError: data.FunctionError,
-                LogResult: log_result,
-                Payload: payload_out
-            });
-        }
+functions.map_response_default = function(err, data, res) {
+  if (err) {
+    winston.error(err);
+    res.status(500).send(err);
+  } else {
+    var payload = !_.isNil(data.Payload) ? JSON.parse(data.Payload) : null;
+    var statusCode = _.isEqual(data.StatusCode, 200) && !_.isNull(payload) && !_.isNull(payload.statusCode) ? payload.statusCode : data.StatusCode;
+    if (!_.isNil(data.FunctionError)) {
+      statusCode = 500;
     }
+    res.status(statusCode);
+    if (!_.isNil(payload) && !_.isNil(payload.headers) && !_.isEmpty(payload.headers)) {
+      res.set(payload.headers);
+    }
+    if (!_.isNil(payload) && !_.isNil(payload.cookies) && !_.isEmpty(payload.cookies)) {
+      _.forEach(payload.cookies, function(cookie) {
+        res.cookie(cookie.name, cookie.value, cookie.options);
+      });
+    }
+    if (!_.isNil(payload) && !_.isNil(payload.redirect)) {
+      res.redirect(statusCode, payload.redirect);
+    } else {
+      if (!_.isNil(payload) && !_.isNil(payload.body)) {
+        var payload_out = payload.body;
+      } else if (!_.isNil(payload)) {
+        var payload_out = payload;
+      } else {
+        var payload_out = null;
+      }
+      var log_result = data.LogResult;
+      if (!_.isNil(log_result)) {
+        try {
+          var b = new Buffer(log_result, 'base64')
+          log_result = b.toString();
+        } catch (err) {
+          winston.error(err);
+        }
+      }
+      res.json({
+        StatusCode: statusCode,
+        FunctionError: data.FunctionError,
+        LogResult: log_result,
+        Payload: payload_out
+      });
+    }
+  }
+};
+
+functions.map_response_simple = function(err, data, res) {
+  if (err) {
+    winston.error(err);
+    res.status(500).send(err);
+  } else {
+    var payload = !_.isNil(data.Payload) ? JSON.parse(data.Payload) : null;
+    var statusCode = _.isEqual(data.StatusCode, 200) && !_.isNull(payload) && !_.isNull(payload.statusCode) ? payload.statusCode : data.StatusCode;
+    if (!_.isNil(data.FunctionError)) {
+      statusCode = 500;
+    }
+    res.status(statusCode);
+    if (!_.isNil(payload) && !_.isNil(payload.headers) && !_.isEmpty(payload.headers)) {
+      res.set(payload.headers);
+    }
+    if (!_.isNil(payload) && !_.isNil(payload.cookies) && !_.isEmpty(payload.cookies)) {
+      _.forEach(payload.cookies, function(cookie) {
+        res.cookie(cookie.name, cookie.value, cookie.options);
+      });
+    }
+    if (!_.isNil(payload) && !_.isNil(payload.redirect)) {
+      res.redirect(statusCode, payload.redirect);
+    } else {
+      if (!_.isNil(payload) && !_.isNil(payload.body)) {
+        var payload_out = payload.body;
+      } else if (!_.isNil(payload)) {
+        var payload_out = payload;
+      } else {
+        var payload_out = null;
+      }
+
+      res.json(payload_out);
+    }
+  }
 };
 
 /**
@@ -96,14 +131,25 @@ functions.invoke = function(options) {
 
   return function invoke(req, res, next) {
     if (_.isNil(req.header('x-FunctionName'))) {
-        res.status(400).send("Please provide an AWS Lambda function name in the form of a 'x-FunctionName' header.");
-        return next();
+      res.status(400).send("Please provide an AWS Lambda function name in the form of a 'x-FunctionName' header.");
+      return next();
     }
+
+    var viewtype = _.isNil(req.header('x-ViewType')) ? 'default' : req.header('x-ViewType')
+
     options.region = !_.isNil(req.header('x-Region')) ? req.header('x-Region') : 'us-east-1';
     var lambda = new AWS.Lambda(options);
     lambda.invoke(functions.map_request(req), function (err, data) {
-        functions.map_response(err, data, res);
-        return next();
+      switch(viewtype) {
+        case 'simple':
+          functions.map_response_simple(err, data, res);
+          break;
+        case 'default':
+        default:
+          functions.map_response_default(err, data, res);
+      }
+
+      return next();
     });
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "lambda-http-proxy",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Proxy http requests to lambda functions",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "nyc --reporter=text --reporter=html mocha"
   },
   "repository": {
     "type": "git",
@@ -34,6 +34,7 @@
     "cookie-parser": "^1.4.3",
     "express": "^4.14.0",
     "mocha": "^3.1.2",
+    "nyc": "^13.1.0",
     "should": "^11.1.1",
     "supertest": "^2.0.1"
   }

--- a/test/app.js
+++ b/test/app.js
@@ -10,11 +10,14 @@ app.use(cookieParser());
 
 app.all('/api', lambda_http_proxy.invoke());
 app.all('/map-request', function(req, res, next) {
-    res.status(200);
-    res.json(lambda_http_proxy.map_request(req));
+  res.status(200);
+  res.json(lambda_http_proxy.map_request(req));
 });
-app.all('/map-response', function(req, res, next) {
-    lambda_http_proxy.map_response(req.body.err, req.body.data, res);
+app.all('/map-response-default', function(req, res, next) {
+  lambda_http_proxy.map_response_default(req.body.err, req.body.data, res);
+});
+app.all('/map-response-simple', function(req, res, next) {
+  lambda_http_proxy.map_response_simple(req.body.err, req.body.data, res);
 });
 
 app.set('port', 3000);

--- a/test/test.js
+++ b/test/test.js
@@ -6,155 +6,275 @@ var _ = require('lodash');
 var app = require('./app');
 
 describe('Test', function(){
-    it('missing x-FunctionName', function(done){
-        request(app)
-            .get('/api')
-            .set('Accept', 'application/json')
-            .expect(400, "Please provide an AWS Lambda function name in the form of a 'x-FunctionName' header.", done);
-    });
-    it('invalid region', function(done){
-        request(app)
-            .get('/api')
-            .set('Accept', 'application/json')
-            .set('x-Region', 'invalid-region')
-            .expect(400, done);
-    });
-    it('invalid function name', function(done){
-        request(app)
-            .get('/api')
-            .set('Accept', 'application/json')
-            .set('x-FunctionName', 'not-found')
-            .expect(500, done);
-    });
-    it('Test request mapping', function(done){
-        request(app)
-            .post('/map-request?param1=yes&param2=no')
-            .set('Accept', 'application/json')
-            .set('x-FunctionName', 'function-name')
-            .set('x-Qualifier', 'qualifier')
-            .set('x-LogType', 'Tail')
-            .set('Cookie', 'cookie1=12345667')
-            .send({
-                foo: 'bar'
-            })
-            .expect(function (res) {
-                winston.info(JSON.stringify(res.body, null, 3));
-                assert.equal(res.statusCode, 200, 'statusCode should be 200, was:'+res.statusCode);
-                assert.equal(res.body.FunctionName, 'function-name');
-                assert.equal(res.body.Qualifier, 'qualifier');
-                assert.equal(res.body.LogType, 'Tail');
-                var body = JSON.parse(res.body.Payload);
-                assert.equal(body.body.foo, 'bar');
-                assert.equal(body.path, '/map-request');
-                assert.equal(body.url, '/map-request?param1=yes&param2=no');
-                assert.equal(body.query.param1, 'yes');
-                assert.equal(body.cookies.cookie1, '12345667');
-            })
-            .end(done);
-    });
-    it('Test response mapping', function(done){
-        request(app)
-            .post('/map-response')
-            .set('Accept', 'application/json')
-            .send({
-                data: {
-                    StatusCode: 200,
-                    LogResult: 'logresult',
-                    Payload: JSON.stringify({
-                        statusCode: 200,
-                        body: {
-                            foo: 'bar'
-                        }
-                    })
-                }
-            })
-            .expect(function (res) {
-                winston.info(JSON.stringify(res.body, null, 3));
-                assert.equal(res.statusCode, 200, 'statusCode should be 200, was:'+res.statusCode);
-                assert.equal(res.body.StatusCode, 200);
-                assert.equal(res.body.Payload.foo, 'bar');
-            })
-            .end(done);
-    });
-    it('Test response mapping - 500', function(done){
-        request(app)
-            .post('/map-response')
-            .set('Accept', 'application/json')
-            .send({
-                data: {
-                    StatusCode: 500,
-                    FunctionError: 'error',
-                    Payload: JSON.stringify({
-                        statusCode: 200,
-                        body: {
-                            foo: 'bar'
-                        }
-                    })
-                }
-            })
-            .expect(function (res) {
-                winston.info(JSON.stringify(res.body, null, 3));
-                assert.equal(res.statusCode, 500, 'statusCode should be 500, was:'+res.statusCode);
-                assert.equal(res.body.StatusCode, 500);
-                assert.equal(res.body.FunctionError, 'error');
-                assert.equal(res.body.Payload.foo, 'bar');
-            })
-            .end(done);
-    });
-    it('Test response mapping - 400', function(done){
-        request(app)
-            .post('/map-response')
-            .set('Accept', 'application/json')
-            .send({
-                data: {
-                    StatusCode: 200,
-                    Payload: JSON.stringify({
-                        statusCode: 400,
-                        body: {
-                            foo: 'bar'
-                        }
-                    })
-                }
-            })
-            .expect(function (res) {
-                winston.info(JSON.stringify(res, null, 3));
-                assert.equal(res.status, 400, 'statusCode should be 400, was:'+res.status);
-            })
-            .end(done);
-    });
-    it('Test response mapping - headers, cookies', function(done){
-        request(app)
-            .post('/map-response')
-            .set('Accept', 'application/json')
-            .send({
-                data: {
-                    StatusCode: 200,
-                    LogResult: 'logresult',
-                    Payload: JSON.stringify({
-                        statusCode: 200,
-                        body: {
-                            foo: 'bar'
-                        },
-                        headers: {
-                            'header1': 'value1'
-                        },
-                        cookies: [
-                            {
-                                name: 'cookie1',
-                                value: 'value1',
-                                options: { maxAge: 900000, httpOnly: true }
-                            }
-                        ]
-                    })
-                }
-            })
-            .expect(function (res) {
-                winston.info(JSON.stringify(res.body, null, 3));
-                assert.equal(res.status, 200, 'statusCode should be 200, was:'+res.statusCode);
-                assert.equal(res.body.StatusCode, 200);
-                assert.equal(res.body.Payload.foo, 'bar');
-                assert.equal(res.get('header1'), 'value1');
-            })
-            .end(done);
-    });
+  it('missing x-FunctionName', function(done){
+    request(app)
+      .get('/api')
+      .set('Accept', 'application/json')
+      .expect(400, "Please provide an AWS Lambda function name in the form of a 'x-FunctionName' header.", done);
+  });
+  it('invalid region', function(done){
+    request(app)
+      .get('/api')
+      .set('Accept', 'application/json')
+      .set('x-Region', 'invalid-region')
+      .expect(400, done);
+  });
+  it('invalid function name', function(done){
+    request(app)
+      .get('/api')
+      .set('Accept', 'application/json')
+      .set('x-FunctionName', 'not-found')
+      .expect(500, done);
+  });
+  it('invalid function name default ViewType', function(done){
+    request(app)
+      .get('/api')
+      .set('Accept', 'application/json')
+      .set('x-FunctionName', 'not-found')
+      .set('x-ViewType', 'default')
+      .expect(500, done);
+  });
+  it('invalid function name simple ViewType', function(done){
+    request(app)
+      .get('/api')
+      .set('Accept', 'application/json')
+      .set('x-FunctionName', 'not-found')
+      .set('x-ViewType', 'simple')
+      .expect(500, done);
+  });
+  it('Test request mapping', function(done){
+    request(app)
+      .post('/map-request?param1=yes&param2=no')
+      .set('Accept', 'application/json')
+      .set('x-FunctionName', 'function-name')
+      .set('x-Qualifier', 'qualifier')
+      .set('x-LogType', 'Tail')
+      .set('Cookie', 'cookie1=12345667')
+      .send({
+        foo: 'bar'
+      })
+      .expect(function (res) {
+        winston.info(JSON.stringify(res.body, null, 3));
+        assert.equal(res.statusCode, 200, 'statusCode should be 200, was:'+res.statusCode);
+        assert.equal(res.body.FunctionName, 'function-name');
+        assert.equal(res.body.Qualifier, 'qualifier');
+        assert.equal(res.body.LogType, 'Tail');
+        var body = JSON.parse(res.body.Payload);
+        assert.equal(body.body.foo, 'bar');
+        assert.equal(body.path, '/map-request');
+        assert.equal(body.url, '/map-request?param1=yes&param2=no');
+        assert.equal(body.query.param1, 'yes');
+        assert.equal(body.cookies.cookie1, '12345667');
+      })
+      .end(done);
+  });
+  it('Test default response mapping', function(done){
+    request(app)
+      .post('/map-response-default')
+      .set('Accept', 'application/json')
+      .send({
+        data: {
+          StatusCode: 200,
+          LogResult: 'logresult',
+          Payload: JSON.stringify({
+            statusCode: 200,
+            body: {
+              foo: 'bar'
+            }
+          })
+        }
+      })
+      .expect(function (res) {
+        winston.info(JSON.stringify(res.body, null, 3));
+        assert.equal(res.statusCode, 200, 'statusCode should be 200, was:'+res.statusCode);
+        assert.equal(res.body.StatusCode, 200);
+        assert.equal(res.body.Payload.foo, 'bar');
+      })
+      .end(done);
+  });
+  it('Test default response mapping - 500', function(done){
+    request(app)
+      .post('/map-response-default')
+      .set('Accept', 'application/json')
+      .send({
+        data: {
+          StatusCode: 500,
+          FunctionError: 'error',
+          Payload: JSON.stringify({
+            statusCode: 200,
+            body: {
+              foo: 'bar'
+            }
+          })
+        }
+      })
+      .expect(function (res) {
+        winston.info(JSON.stringify(res.body, null, 3));
+        assert.equal(res.statusCode, 500, 'statusCode should be 500, was:'+res.statusCode);
+        assert.equal(res.body.StatusCode, 500);
+        assert.equal(res.body.FunctionError, 'error');
+        assert.equal(res.body.Payload.foo, 'bar');
+      })
+      .end(done);
+  });
+  it('Test default response mapping - 400', function(done){
+    request(app)
+      .post('/map-response-default')
+      .set('Accept', 'application/json')
+      .send({
+        data: {
+          StatusCode: 200,
+          Payload: JSON.stringify({
+            statusCode: 400,
+            body: {
+              foo: 'bar'
+            }
+          })
+        }
+      })
+      .expect(function (res) {
+        winston.info(JSON.stringify(res, null, 3));
+        assert.equal(res.status, 400, 'statusCode should be 400, was:'+res.status);
+      })
+      .end(done);
+  });
+  it('Test default response mapping - headers, cookies', function(done){
+    request(app)
+      .post('/map-response-default')
+      .set('Accept', 'application/json')
+      .send({
+        data: {
+          StatusCode: 200,
+          LogResult: 'logresult',
+          Payload: JSON.stringify({
+            statusCode: 200,
+            body: {
+              foo: 'bar'
+            },
+            headers: {
+              'header1': 'value1'
+            },
+            cookies: [
+              {
+                name: 'cookie1',
+                value: 'value1',
+                options: { maxAge: 900000, httpOnly: true }
+              }
+            ]
+          })
+        }
+      })
+      .expect(function (res) {
+        winston.info(JSON.stringify(res.body, null, 3));
+        assert.equal(res.status, 200, 'statusCode should be 200, was:'+res.statusCode);
+        assert.equal(res.body.StatusCode, 200);
+        assert.equal(res.body.Payload.foo, 'bar');
+        assert.equal(res.get('header1'), 'value1');
+      })
+      .end(done);
+  });
+  it('Test simple response mapping', function(done){
+    request(app)
+      .post('/map-response-simple')
+      .set('Accept', 'application/json')
+      .send({
+        data: {
+          StatusCode: 200,
+          LogResult: 'logresult',
+          Payload: JSON.stringify({
+            statusCode: 200,
+            body: {
+              foo: 'bar'
+            }
+          })
+        }
+      })
+      .expect(function (res) {
+        winston.info(JSON.stringify(res.body, null, 3));
+        assert.equal(res.statusCode, 200, 'statusCode should be 200, was:'+res.statusCode);
+        assert.equal(res.body.foo, 'bar');
+      })
+      .end(done);
+  });
+  it('Test simple response mapping - 500', function(done){
+    request(app)
+      .post('/map-response-simple')
+      .set('Accept', 'application/json')
+      .send({
+        data: {
+          StatusCode: 500,
+          FunctionError: 'error',
+          Payload: JSON.stringify({
+            statusCode: 200,
+            body: {
+              foo: 'bar'
+            }
+          })
+        }
+      })
+      .expect(function (res) {
+        winston.info(JSON.stringify(res.body, null, 3));
+        assert.equal(res.statusCode, 500, 'statusCode should be 500, was:'+res.statusCode);
+        assert.equal(res.body.StatusCode, null);
+        assert.equal(res.body.FunctionError, null);
+        assert.equal(res.body.foo, 'bar');
+      })
+      .end(done);
+  });
+  it('Test simple response mapping - 400', function(done){
+    request(app)
+      .post('/map-response-default')
+      .set('Accept', 'application/json')
+      .send({
+        data: {
+          StatusCode: 200,
+          Payload: JSON.stringify({
+            statusCode: 400,
+            body: {
+              foo: 'bar'
+            }
+          })
+        }
+      })
+      .expect(function (res) {
+        winston.info(JSON.stringify(res, null, 3));
+        assert.equal(res.status, 400, 'statusCode should be 400, was:'+res.status);
+      })
+      .end(done);
+  });
+  it('Test simple response mapping - headers, cookies', function(done){
+    request(app)
+      .post('/map-response-simple')
+      .set('Accept', 'application/json')
+      .send({
+        data: {
+          StatusCode: 200,
+          LogResult: 'logresult',
+          Payload: JSON.stringify({
+            statusCode: 200,
+            body: {
+              foo: 'bar'
+            },
+            headers: {
+              'header1': 'value1'
+            },
+            cookies: [
+              {
+                name: 'cookie1',
+                value: 'value1',
+                options: { maxAge: 900000, httpOnly: true }
+              }
+            ]
+          })
+        }
+      })
+      .expect(function (res) {
+        winston.info(JSON.stringify(res.body, null, 3));
+        assert.equal(res.status, 200, 'statusCode should be 200, was:'+res.statusCode);
+        assert.equal(res.body.StatusCode, null);
+        assert.equal(res.body.foo, 'bar');
+        assert.equal(res.get('header1'), 'value1');
+      })
+      .end(done);
+  });
 });


### PR DESCRIPTION
### What's changed?
Added a new response format that returns just Payload.body in the response body instead of JSON of the format below.
```
{
  "StatusCode":"200",
  "FunctionError":"blahblah",
  "LogResult":"blahblah",
  "Payload":"blahblah"
}
```
Requests that include a X-ViewType header with value of 'simple' will trigger the use of the new response view.  The absence of X-ViewType header or a value of 'standard' will use the current response view.

Pub Stack Team needs this functionality in Trident for REST APIs we are building in Lambda.

### How was it tested?
Unit tests and manually in Trident.